### PR TITLE
float4 and more efficient index caculate

### DIFF
--- a/wkv5/cuda/wkv5_cuda_v1.cu
+++ b/wkv5/cuda/wkv5_cuda_v1.cu
@@ -40,66 +40,6 @@ __global__ void kernel_forward(const int B, const int T, const int C, const int 
 }
 
 template <typename F>
-__global__ void kernel_forward_float4(const int B, const int T, const int C, const int H,
-                                      const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u,
-                                      F *__restrict__ const _y)
-{
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const int _b = idx / (C / 4);
-    const int _h = (idx / (N / 4)) % H;
-    const int _i = (idx % (N / 4)) * 4;
-
-    const int _o0 = _b * T * C + _h * N;
-    const int _o1 = _h * N;
-
-    const float4 *__restrict__ const k = (float4 *)(_k + _o0);
-    const float4 *__restrict__ const v = (float4 *)(_v + _o0 + _i / 4); 
-    const float4 *__restrict__ const r = (float4 *)(_r + _o0);
-    float4 *__restrict__ const y = (float4 *)(_y + _o0 + _i / 4); 
-
-    __align__(16) float4 state[N / 4] = { make_float4(0.0f, 0.0f, 0.0f, 0.0f) };
-
-    for (int __t = 0; __t < T; __t++)
-    {
-        const int _t = __t * (C / 4); 
-        const float4 vv = v[_t];
-
-        for (int _j = 0; _j < N / 4; _j++)
-        {
-            const int j = _t + _j;
-            const int m = _o1 + _j * 4; 
-
-            const float4 k_val = k[j];
-            const float4 r_val = r[j];
-            float4 x;
-            x.x = k_val.x * vv.x;
-            x.y = k_val.y * vv.y;
-            x.z = k_val.z * vv.z;
-            x.w = k_val.w * vv.w;
-
-            float4 s = state[_j];
-
-            float4 result;
-            result.x = r_val.x * (_u[m] * x.x + s.x);
-            result.y = r_val.y * (_u[m + 1] * x.y + s.y);
-            result.z = r_val.z * (_u[m + 2] * x.z + s.z);
-            result.w = r_val.w * (_u[m + 3] * x.w + s.w);
-
-            atomicAdd(&(y[_t].x), result.x);
-            atomicAdd(&(y[_t].y), result.y);
-            atomicAdd(&(y[_t].z), result.z);
-            atomicAdd(&(y[_t].w), result.w);
-
-            state[_j].x = s.x * _w[m] + x.x;
-            state[_j].y = s.y * _w[m + 1] + x.y;
-            state[_j].z = s.z * _w[m + 2] + x.z;
-            state[_j].w = s.w * _w[m + 3] + x.w;
-        }
-    }
-}
-
-
-template <typename F>
 __global__ void kernel_backward(const int B, const int T, const int C, const int H,
                                 const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u, const F *__restrict__ const _gy,
                                 F *__restrict__ const _gr, F *__restrict__ const _gk, F *__restrict__ const _gv, F *__restrict__ const _gw, F *__restrict__ const _gu)
@@ -109,18 +49,10 @@ __global__ void kernel_backward(const int B, const int T, const int C, const int
 
 void cuda_forward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *y)
 {
-    if (N % 4 == 0 && C % 4 == 0){
-        dim3 threadsPerBlock( min(B * C / 4, 32) );
-        assert((B * C / 4) % threadsPerBlock.x == 0);
-        dim3 numBlocks(B * C / 4 / threadsPerBlock.x);
-        kernel_forward_float4<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
-    }
-    else{
-        dim3 threadsPerBlock( min(B*C, 32) );
-        assert(B * C % threadsPerBlock.x == 0);
-        dim3 numBlocks(B * C / threadsPerBlock.x);
-        kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
-    }
+    dim3 threadsPerBlock( min(B*C, 32) );
+    assert(B * C % threadsPerBlock.x == 0);
+    dim3 numBlocks(B * C / threadsPerBlock.x);
+    kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
 }
 
 void cuda_backward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *gy, float *gr, float *gk, float *gv, float *gw, float *gu)

--- a/wkv5/cuda/wkv5_cuda_v1.cu
+++ b/wkv5/cuda/wkv5_cuda_v1.cu
@@ -7,10 +7,11 @@ __global__ void kernel_forward(const int B, const int T, const int C, const int 
                                F *__restrict__ const _y)
 {
     const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int _b = idx / C;
+    const int _h = (idx / N) % H;
     const int _i = idx % N;
-    const int _b = (idx/N) / H;
-    const int _h = (idx/N) % H;
-    const int _o0 = _b*T*H*N + _h*N;
+
+    const int _o0 = _b*T*C + _h*N;
     const int _o1 = _h*N;
     const F *__restrict__ const k = _k + _o0;
     const F *__restrict__ const v = _v + _o0 + _i;
@@ -19,23 +20,84 @@ __global__ void kernel_forward(const int B, const int T, const int C, const int 
 
     float state[N] = {0};   
 
-    for (int _t = 0; _t < T; _t++)
+    for (int __t = 0; __t < T; __t++)
     {
-        const F vv = v[_t*H*N];
+        const int _t = __t*C;
+        const F vv = v[_t];
 
         for (int _j = 0; _j < N; _j++) 
         {
-            const int j = _t*H*N + _j;
+            const int j = _t + _j;
             const int m = _o1 + _j;
 
             const float x = k[j] * vv;
             const float s = state[_j];
             
-            atomicAdd(&(y[_t*H*N]), r[j] * (_u[m] * x + s));
+            atomicAdd(y + _t, r[j] * (_u[m] * x + s));
             state[_j] = s * _w[m] + x;
         }
     }
 }
+
+template <typename F>
+__global__ void kernel_forward_float4(const int B, const int T, const int C, const int H,
+                                      const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u,
+                                      F *__restrict__ const _y)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int _b = idx / (C / 4);
+    const int _h = (idx / (N / 4)) % H;
+    const int _i = (idx % (N / 4)) * 4;
+
+    const int _o0 = _b * T * C + _h * N;
+    const int _o1 = _h * N;
+
+    const float4 *__restrict__ const k = (float4 *)(_k + _o0);
+    const float4 *__restrict__ const v = (float4 *)(_v + _o0 + _i / 4); 
+    const float4 *__restrict__ const r = (float4 *)(_r + _o0);
+    float4 *__restrict__ const y = (float4 *)(_y + _o0 + _i / 4); 
+
+    __align__(16) float4 state[N / 4] = { make_float4(0.0f, 0.0f, 0.0f, 0.0f) };
+
+    for (int __t = 0; __t < T; __t++)
+    {
+        const int _t = __t * (C / 4); 
+        const float4 vv = v[_t];
+
+        for (int _j = 0; _j < N / 4; _j++)
+        {
+            const int j = _t + _j;
+            const int m = _o1 + _j * 4; 
+
+            const float4 k_val = k[j];
+            const float4 r_val = r[j];
+            float4 x;
+            x.x = k_val.x * vv.x;
+            x.y = k_val.y * vv.y;
+            x.z = k_val.z * vv.z;
+            x.w = k_val.w * vv.w;
+
+            float4 s = state[_j];
+
+            float4 result;
+            result.x = r_val.x * (_u[m] * x.x + s.x);
+            result.y = r_val.y * (_u[m + 1] * x.y + s.y);
+            result.z = r_val.z * (_u[m + 2] * x.z + s.z);
+            result.w = r_val.w * (_u[m + 3] * x.w + s.w);
+
+            atomicAdd(&(y[_t].x), result.x);
+            atomicAdd(&(y[_t].y), result.y);
+            atomicAdd(&(y[_t].z), result.z);
+            atomicAdd(&(y[_t].w), result.w);
+
+            state[_j].x = s.x * _w[m] + x.x;
+            state[_j].y = s.y * _w[m + 1] + x.y;
+            state[_j].z = s.z * _w[m + 2] + x.z;
+            state[_j].w = s.w * _w[m + 3] + x.w;
+        }
+    }
+}
+
 
 template <typename F>
 __global__ void kernel_backward(const int B, const int T, const int C, const int H,
@@ -47,10 +109,18 @@ __global__ void kernel_backward(const int B, const int T, const int C, const int
 
 void cuda_forward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *y)
 {
-    dim3 threadsPerBlock( min(B*C, 32) );
-    assert(B * C % threadsPerBlock.x == 0);
-    dim3 numBlocks(B * C / threadsPerBlock.x);
-    kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    if (N % 4 == 0 && C % 4 == 0){
+        dim3 threadsPerBlock( min(B * C / 4, 32) );
+        assert((B * C / 4) % threadsPerBlock.x == 0);
+        dim3 numBlocks(B * C / 4 / threadsPerBlock.x);
+        kernel_forward_float4<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    }
+    else{
+        dim3 threadsPerBlock( min(B*C, 32) );
+        assert(B * C % threadsPerBlock.x == 0);
+        dim3 numBlocks(B * C / threadsPerBlock.x);
+        kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    }
 }
 
 void cuda_backward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *gy, float *gr, float *gk, float *gv, float *gw, float *gu)

--- a/wkv5/cuda/wkv5_cuda_v2.cu
+++ b/wkv5/cuda/wkv5_cuda_v2.cu
@@ -1,0 +1,94 @@
+#include <stdio.h>
+#include <assert.h>
+
+template <typename F>
+__global__ void kernel_forward(const int B, const int T, const int C, const int H,
+                                      const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u,
+                                      F *__restrict__ const _y)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int idx_div_n_4 = idx / (N >> 2);
+    const int _b = idx / (C >> 2);
+    const int _h = idx_div_n_4 - idx_div_n_4 / H * H ;
+    const int _i = (idx -  idx_div_n_4 * (N >> 2)) << 2;
+
+    const int _o0 = _b * T * C + _h * N;
+    const int _o1 = _h * N;
+
+    const float4 *__restrict__ const k = (float4 *)(_k + _o0);
+    const float4 *__restrict__ const v =  (float4 *)(_v + _o0 + _i); 
+    const float4 *__restrict__ const r = (float4 *)(_r + _o0);
+    float4 *__restrict__ const y = (float4 *)(_y + _o0 + _i); 
+
+    __align__(16) float4 state[N / 4] = { make_float4(0.0f, 0.0f, 0.0f, 0.0f) };
+
+    for (int __t = 0; __t < T; __t++)
+    {
+        const int _t = __t * (C / 4); 
+        const float4 vv = v[_t];
+
+        for (int _j = 0; _j < N / 4; _j++)
+        {
+            const int j = _t + _j;
+            const int m = _o1 + _j * 4; 
+
+            const float4 k_val = k[j];
+            const float4 r_val = r[j];
+            float4 x;
+            x.x = k_val.x * vv.x;
+            x.y = k_val.y * vv.y;
+            x.z = k_val.z * vv.z;
+            x.w = k_val.w * vv.w;
+
+            float4 s = state[_j];
+
+            float4 result;
+            result.x = r_val.x * (_u[m] * x.x + s.x);
+            result.y = r_val.y * (_u[m + 1] * x.y + s.y);
+            result.z = r_val.z * (_u[m + 2] * x.z + s.z);
+            result.w = r_val.w * (_u[m + 3] * x.w + s.w);
+
+            atomicAdd(&(y[_t].x), result.x);
+            atomicAdd(&(y[_t].y), result.y);
+            atomicAdd(&(y[_t].z), result.z);
+            atomicAdd(&(y[_t].w), result.w);
+
+            state[_j].x = s.x * _w[m] + x.x;
+            state[_j].y = s.y * _w[m + 1] + x.y;
+            state[_j].z = s.z * _w[m + 2] + x.z;
+            state[_j].w = s.w * _w[m + 3] + x.w;
+        }
+    }
+}
+
+template <typename F>
+__global__ void kernel_backward(const int B, const int T, const int C, const int H,
+                                const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u, const F *__restrict__ const _gy,
+                                F *__restrict__ const _gr, F *__restrict__ const _gk, F *__restrict__ const _gv, F *__restrict__ const _gw, F *__restrict__ const _gu)
+{
+    
+}
+
+void cuda_forward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *y)
+{
+    if (N % 4 == 0 && C % 4 == 0){
+        dim3 threadsPerBlock( min(B * C / 4, 32) );
+        assert((B * C / 4) % threadsPerBlock.x == 0);
+        dim3 numBlocks(B * C / 4 / threadsPerBlock.x);
+        kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    }
+    else{
+        dim3 threadsPerBlock( min(B*C, 32) );
+        assert(B * C % threadsPerBlock.x == 0);
+        dim3 numBlocks(B * C / threadsPerBlock.x);
+        kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    }
+}
+
+void cuda_backward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *gy, float *gr, float *gk, float *gv, float *gw, float *gu)
+{
+    dim3 threadsPerBlock( min(B*C, 32) );
+    assert(B * C % threadsPerBlock.x == 0);
+    dim3 numBlocks(B * C / threadsPerBlock.x);
+    kernel_backward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, gy, gr, gk, gv, gw, gu);
+}

--- a/wkv5/run.py
+++ b/wkv5/run.py
@@ -90,41 +90,6 @@ def RUN_FORMULA_2(B, T, C, H, r, k, v, w, u):
 
     return out.view(B, T, C)
 
-def RUN_FORMULA_3(B, T, C, H, r, k, v, w, u):
-    N = C // H
-    r = r.flatten().contiguous() # BTHN
-    k = k.flatten().contiguous() # BTHN
-    v = v.flatten().contiguous() # BTHN
-    w = w.flatten().contiguous() # HN
-    u = u.flatten().contiguous() # HN
-    out = torch.zeros(B*T*C, device=DEVICE).contiguous()
-
-    for h in range(H):
-        for b in range(B):
-            state = torch.zeros(N*N, device=DEVICE).contiguous()
-            for t in range(T):
-                _o0 = b*H*T*N + t*H*N + h*N
-                _o1 = h*N
-
-                for _i in range(N):
-
-                    i = _o0 + _i
-
-                    for _j in range(N):
-
-                        j = _o0 + _j
-                        m = _o1 + _j
-                        ij = _i * N + _j
-
-                        x = k[j] * v[i]
-                        s = state[ij]
-
-                        out[i] += r[j] * (u[m] * x + s)
-                        state[ij] = s * w[m] + x
-
-
-    return out.view(B, T, C)
-
 ######################################################################################################
 # CUDA kernel
 ######################################################################################################
@@ -211,14 +176,11 @@ def CHECK_CORRECT():
     y1 = RUN_FORMULA_2(B, T, C, H, r, k, v, w, u)
     print('result', val(y1), '\n\n')
 
-    y2 = RUN_FORMULA_3(B, T, C, H, r, k, v, w, u)
+    y2 = RUN_CUDA(B, T, C, H, r, k, v, w, u)
     print('result', val(y2), '\n\n')
 
-    y3 = RUN_CUDA(B, T, C, H, r, k, v, w, u)
-    print('result', val(y3), '\n\n')
-
-    print('--> correct =', torch.allclose(y0, y1), torch.allclose(y0, y2), torch.allclose(y1, y2), torch.allclose(y1, y3),
-          ', err ratio =', get_err_ratio(y0, y1), get_err_ratio(y0, y2), get_err_ratio(y1, y2), get_err_ratio(y1, y3))
+    print('--> correct =', torch.allclose(y0, y1), torch.allclose(y0, y2),
+          ', err ratio =', get_err_ratio(y0, y1), get_err_ratio(y0, y2))
 
 def CHECK_SPEED(silent=False):
 


### PR DESCRIPTION
In A800:

main:

CUDA warmup...
B 8 T 4096 C 4096 H 64
B 8 T 4096 C 4096 H 64
CUDA forward
 -------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                     Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                    WKV_5         0.26%     105.000us         0.40%     160.000us     160.000us      39.143ms        99.20%      39.444ms      39.444ms             1  
              aten::fill_         0.02%       8.000us         0.04%      16.000us      16.000us     278.000us         0.70%     278.000us     278.000us             1  
                 aten::to         0.01%       3.000us         0.01%       3.000us       0.600us      15.000us         0.04%      15.000us       3.000us             5  
              aten::zeros         0.04%      16.000us         0.12%      49.000us      49.000us      13.000us         0.03%     301.000us     301.000us             1  
              aten::zero_         0.02%       9.000us         0.06%      25.000us      25.000us       7.000us         0.02%     285.000us     285.000us             1  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 39.627ms
Self CUDA time total: 39.459ms


pr:


CUDA warmup...
B 8 T 4096 C 4096 H 64
B 8 T 4096 C 4096 H 64
CUDA forward
 -------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                     Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
                    WKV_5         0.19%      67.000us         0.35%     121.000us     121.000us      34.180ms        99.03%      34.496ms      34.496ms             1  
              aten::fill_         0.02%       7.000us         0.04%      15.000us      15.000us     281.000us         0.81%     281.000us     281.000us             1  
                 aten::to         0.01%       2.000us         0.01%       2.000us       0.400us      20.000us         0.06%      20.000us       4.000us             5  
              aten::zeros         0.05%      17.000us         0.14%      50.000us      50.000us      14.000us         0.04%     316.000us     316.000us             1  
              aten::empty         0.02%       8.000us         0.02%       8.000us       8.000us      12.000us         0.03%      12.000us      12.000us             1  
-------------------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 34.537ms
Self CUDA time total: 34.516ms


small speed ratio:

**39.5ms->34.5ms** 。
