### PR TITLE
Faster kernel

### DIFF
--- a/wkv5/cuda/wkv5_cuda_v3.cu
+++ b/wkv5/cuda/wkv5_cuda_v3.cu
@@ -1,0 +1,95 @@
+#include <stdio.h>
+#include <assert.h>
+
+template <typename F>
+__global__ void kernel_forward(const int B, const int T, const int C, const int H,
+                                      const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u,
+                                      F *__restrict__ const _y)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int idx_div_n_4 = idx / (N >> 2);
+    const int _b = idx / (C >> 2);
+    const int _h = idx_div_n_4 - idx_div_n_4 / H * H ;
+    const int _i = (idx -  idx_div_n_4 * (N >> 2)) << 2;
+
+    const int _o0 = _b * T * C + _h * N;
+    const int _o1 = _h * N;
+
+    const float4 *__restrict__ const k = (float4 *)(_k + _o0);
+    const float4 *__restrict__ const v =  (float4 *)(_v + _o0 + _i); 
+    const float4 *__restrict__ const r = (float4 *)(_r + _o0);
+    float4 *__restrict__ const y = (float4 *)(_y + _o0 + _i); 
+
+    __align__(16) float4 state[N / 4] = { make_float4(0.0f, 0.0f, 0.0f, 0.0f) };
+
+    for (int __t = 0; __t < T; __t++)
+    {
+        const int _t = __t * (C / 4); 
+        const float4 vv = v[_t];
+
+        float4 result = make_float4(0.0f, 0.0f, 0.0f, 0.0f);
+
+        for (int _j = 0; _j < N / 4; _j++)
+        {
+            const int j = _t + _j;
+            const int m = _o1 + _j * 4; 
+
+            const float4 k_val = k[j];
+            const float4 r_val = r[j];
+            float4 x;
+            x.x = k_val.x * vv.x;
+            x.y = k_val.y * vv.y;
+            x.z = k_val.z * vv.z;
+            x.w = k_val.w * vv.w;
+
+            float4 s = state[_j];
+
+            result.x += r_val.x * (_u[m] * x.x + s.x);
+            result.y += r_val.y * (_u[m + 1] * x.y + s.y);
+            result.z += r_val.z * (_u[m + 2] * x.z + s.z);
+            result.w += r_val.w * (_u[m + 3] * x.w + s.w);
+
+            state[_j].x = s.x * _w[m] + x.x;
+            state[_j].y = s.y * _w[m + 1] + x.y;
+            state[_j].z = s.z * _w[m + 2] + x.z;
+            state[_j].w = s.w * _w[m + 3] + x.w;
+        }
+
+        atomicAdd(&(y[_t].x), result.x);
+        atomicAdd(&(y[_t].y), result.y);
+        atomicAdd(&(y[_t].z), result.z);
+        atomicAdd(&(y[_t].w), result.w);
+    }
+}
+
+template <typename F>
+__global__ void kernel_backward(const int B, const int T, const int C, const int H,
+                                const F *__restrict__ const _r, const F *__restrict__ const _k, const F *__restrict__ const _v, const F *__restrict__ const _w, const F *__restrict__ const _u, const F *__restrict__ const _gy,
+                                F *__restrict__ const _gr, F *__restrict__ const _gk, F *__restrict__ const _gv, F *__restrict__ const _gw, F *__restrict__ const _gu)
+{
+    
+}
+
+void cuda_forward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *y)
+{
+    if (N % 4 == 0 && C % 4 == 0){
+        dim3 threadsPerBlock( min(B * C / 4, 32) );
+        assert((B * C / 4) % threadsPerBlock.x == 0);
+        dim3 numBlocks(B * C / 4 / threadsPerBlock.x);
+        kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    }
+    else{
+        dim3 threadsPerBlock( min(B*C, 32) );
+        assert(B * C % threadsPerBlock.x == 0);
+        dim3 numBlocks(B * C / threadsPerBlock.x);
+        kernel_forward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, y);
+    }
+}
+
+void cuda_backward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *u, float *gy, float *gr, float *gk, float *gv, float *gw, float *gu)
+{
+    dim3 threadsPerBlock( min(B*C, 32) );
+    assert(B * C % threadsPerBlock.x == 0);
+    dim3 numBlocks(B * C / threadsPerBlock.x);
+    kernel_backward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, u, gy, gr, gk, gv, gw, gu);
+}

--- a/wkv5/run.py
+++ b/wkv5/run.py
@@ -11,7 +11,7 @@ torch.backends.cudnn.allow_tf32 = False
 torch.backends.cuda.matmul.allow_tf32 = False
 
 DEVICE = 'cuda'
-CUDA_KERNEL_VERSION = 2
+CUDA_KERNEL_VERSION = 3
 
 '''
 python run.py correctness && python run.py benchmark


### PR DESCRIPTION
Only T atomic locks, instead of T*N.

Ran on 3060 on Windows 11 with Docker in WSL2.

v1:
```
Loading extension module wkv5...


CUDA warmup...
B 8 T 4096 C 4096 H 64
WARNING:2023-09-06 20:03:37 377:377 init.cpp:143] function cbapi->getCuptiStatus() failed with error CUPTI_ERROR_NOT_INITIALIZED (15)
WARNING:2023-09-06 20:03:37 377:377 init.cpp:144] CUPTI initialization failed - CUDA profiler activities will be missing
INFO:2023-09-06 20:03:37 377:377 init.cpp:146] If you see CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti
STAGE:2023-09-06 20:03:37 377:377 ActivityProfilerController.cpp:312] Completed Stage: Warm Up
STAGE:2023-09-06 20:03:37 377:377 ActivityProfilerController.cpp:318] Completed Stage: Collection
STAGE:2023-09-06 20:03:37 377:377 ActivityProfilerController.cpp:322] Completed Stage: Post Processing
B 8 T 4096 C 4096 H 64
STAGE:2023-09-06 20:03:37 377:377 ActivityProfilerController.cpp:312] Completed Stage: Warm Up
STAGE:2023-09-06 20:03:37 377:377 ActivityProfilerController.cpp:318] Completed Stage: Collection
STAGE:2023-09-06 20:03:37 377:377 ActivityProfilerController.cpp:322] Completed Stage: Post Processing
CUDA forward
 ---------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
           Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls
---------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
          WKV_5        63.73%      65.000us        98.04%     100.000us     100.000us      74.748ms        97.78%      76.405ms      76.405ms             1
    aten::fill_         7.84%       8.000us         7.84%       8.000us       8.000us       1.647ms         2.15%       1.647ms       1.647ms             1
       aten::to         1.96%       2.000us         1.96%       2.000us       0.400us      42.000us         0.05%      42.000us       8.400us             5
    aten::zeros        17.65%      18.000us        34.31%      35.000us      35.000us       6.000us         0.01%       1.657ms       1.657ms             1
    aten::zero_         5.88%       6.000us        13.73%      14.000us      14.000us       3.000us         0.00%       1.650ms       1.650ms             1
---------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 102.000us
Self CUDA time total: 76.447ms
```

v2:
```
Loading extension module wkv5...


CUDA warmup...
B 8 T 4096 C 4096 H 64
WARNING:2023-09-06 20:06:31 1101:1101 init.cpp:143] function cbapi->getCuptiStatus() failed with error CUPTI_ERROR_NOT_INITIALIZED (15)
WARNING:2023-09-06 20:06:31 1101:1101 init.cpp:144] CUPTI initialization failed - CUDA profiler activities will be missing
INFO:2023-09-06 20:06:31 1101:1101 init.cpp:146] If you see CUPTI_ERROR_INSUFFICIENT_PRIVILEGES, refer to https://developer.nvidia.com/nvidia-development-tools-solutions-err-nvgpuctrperm-cupti
STAGE:2023-09-06 20:06:31 1101:1101 ActivityProfilerController.cpp:312] Completed Stage: Warm Up
STAGE:2023-09-06 20:06:31 1101:1101 ActivityProfilerController.cpp:318] Completed Stage: Collection
STAGE:2023-09-06 20:06:31 1101:1101 ActivityProfilerController.cpp:322] Completed Stage: Post Processing
B 8 T 4096 C 4096 H 64
STAGE:2023-09-06 20:06:31 1101:1101 ActivityProfilerController.cpp:312] Completed Stage: Warm Up
STAGE:2023-09-06 20:06:31 1101:1101 ActivityProfilerController.cpp:318] Completed Stage: Collection
STAGE:2023-09-06 20:06:31 1101:1101 ActivityProfilerController.cpp:322] Completed Stage: Post Processing
CUDA forward
 ---------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
           Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg     Self CUDA   Self CUDA %    CUDA total  CUDA time avg    # of Calls
---------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
          WKV_5        71.74%      99.000us        98.55%     136.000us     136.000us      50.551ms        96.89%      52.144ms      52.144ms             1
    aten::fill_         8.70%      12.000us         8.70%      12.000us      12.000us       1.570ms         3.01%       1.570ms       1.570ms             1
       aten::to         1.45%       2.000us         1.45%       2.000us       0.400us      31.000us         0.06%      31.000us       6.200us             5
    aten::zero_         4.35%       6.000us        13.04%      18.000us      18.000us      16.000us         0.03%       1.586ms       1.586ms             1
    aten::zeros        10.87%      15.000us        26.81%      37.000us      37.000us       4.000us         0.01%       1.593ms       1.593ms             1
---------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------  ------------
Self CPU time total: 138.000us
Self CUDA time total: 52.175ms
```