### PR TITLE
rwkv5 world backward kernel (optimize)

### DIFF
--- a/wkv5/cuda/wkv5_cuda_v1.cu
+++ b/wkv5/cuda/wkv5_cuda_v1.cu
@@ -93,7 +93,7 @@ __global__ void kernel_backward (const int B, const int T, const int C, const in
     for (int j = 0; j < N; ++j)
         state[j * N + i] = 0;
     
-    for (int _t = (b+1)*T*C + h*N + i - N, _tend = b*T*C + h*N + i; _t >= _tend; _t -= C)
+    for (int _t = (b+1)*T*C + h*N + i - C, _tend = b*T*C + h*N + i; _t >= _tend; _t -= C)
     {
         const F rr = r[_t];
         F gkk = 0;

--- a/wkv5/cuda/wkv5_cuda_v1.cu
+++ b/wkv5/cuda/wkv5_cuda_v1.cu
@@ -41,65 +41,50 @@ __global__ void kernel_forward(const int B, const int T, const int C, const int 
 
 template <typename F>
 __global__ void kernel_backward (const int B, const int T, const int C, const int H,
-    const F *__restrict__ const r, const F *__restrict__ const k, const F *__restrict__ const v, const F *__restrict__ const w, const F *__restrict__ const wwww, const F *__restrict__ const _u, const F *__restrict__ const gy,
-    F *__restrict__ const gr, F *__restrict__ const gk, F *__restrict__ const gv, F *__restrict__ const gw, F *__restrict__ const gu)
+    const F *__restrict__ const r, const F *__restrict__ const k, const F *__restrict__ const v, const F *__restrict__ w, const F *__restrict__ const wwww, const F *__restrict__ u, const F *__restrict__ const gy,
+    F *__restrict__ const gr, F *__restrict__ const gk, F *__restrict__ const gv, F *__restrict__ const gw, F *__restrict__ gu)
 {
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    const int b = idx / C;
-    const int h = (idx / N) % H;
-    const int n = idx % N;
+    const int b = blockIdx.x / H;
+    const int h = blockIdx.x % H;
+    const int i = threadIdx.x;
+    w += h*N;
+    u += h*N;
+    gu += h*N;
+
+    __shared__ float state[N * N], vv[N], gyy[N];
+
+    for (int j = 0; j < N; ++j)
+        state[j * N + i] = 0;
     
-    const F u1 = _u[h*N + n];
-    const F w1 = w[h*N + n];
-    const F wwww1 = wwww[h*N + n];
-    F w_pow[4096] = {0.0f};
-    for (int t =0;  t < T; t++){
-        w_pow[t] = pow(w1, t);
-    }
+    const float ww = w[i];
+    const float uu = u[i];
 
-    for (int t = 0; t < T; t++) {
-        const int index1 = b*T*H*N + t*H*N + h*N;
-        const F* v1 = v + index1;
-        const F* k1 = k + index1;
-        const F* r1 = r + index1;
-        const F* gy1 = gy + index1;
-        F* gr1 = gr + index1;
-        F* gk1 = gk + index1;
-        F* gv1 = gv + index1;
+    for (int _t = b*T*C + h*N + i, _tend = (b+1)*T*C + h*N + i; _t < _tend; _t += C)
+    {
+        const F kk = k[_t];
+        const F rr = r[_t];
+        F grr = 0;
+        F guu = 0;
 
-        for (int nn = 0; nn < N; nn++) {
-            for (int tt = 0; tt <= t; tt++) {
-                F w_pow_1 = t-tt-1 >= 0 ? w_pow[t-tt-1] : pow(w1, t-tt-1);
-                F ww = (tt == t) ? u1 : w_pow_1;
-                
-                gr1[n] += ww * k[b*T*H*N + tt*H*N + h*N + n] *
-                    v[b*T*H*N + tt*H*N + h*N + nn] * gy1[nn];
-            }
+        vv[i] = v[_t];
+        gyy[i] = gy[_t];
 
-            for (int tt = t; tt < T; tt++) {
-                F w_pow_1 = tt-t-1 >= 0 ? w_pow[tt-t-1] : pow(w1, tt-t-1);
-                F ww = (tt == t) ? u1 : w_pow_1;
-                
-                gk1[n] += r[b*T*H*N + tt*H*N + h*N + n] * ww *
-                    v1[nn] * gy[b*T*H*N + tt*H*N + h*N + nn];
+        __syncthreads();
 
-                ww = (tt == t) ? _u[h*N + nn] : pow(w[h*N + nn], tt-t-1);
-                
-                gv1[n] += r[b*T*H*N + tt*H*N + h*N + nn] * ww *
-                    k1[nn] * gy[b*T*H*N + tt*H*N + h*N + n];
-            }
+        for (int j = 0; j < N; j++)
+        {
 
-            atomicAdd(gu + h*N + n, r1[n] * k1[n] *
-                    v1[nn] * gy1[nn]);
+            float x = vv[j] * kk;
+            float s = state[j * N + i];
 
-            for (int tt = 0; tt < t-1; tt++) {
-                F w_pow_1 = t-tt-1 >= 0 ? w_pow[t-tt-1] : pow(w1, t-tt-1);
-                F ww = (t-tt-1) * wwww1 * w_pow_1;
-
-                atomicAdd(gw + h*N + n, r1[n] * ww * k[b*T*H*N + tt*H*N + h*N + n] *
-                    v[b*T*H*N + tt*H*N + h*N + nn] * gy1[nn]);
-            }
+            grr += gyy[j] * (uu * x + s);
+            state[j * N + i] = s * ww + x;
+            guu += rr * x * gyy[j];
         }
+        gr[_t] = grr;
+        atomicAdd(gu + i, guu);
+
+        __syncthreads();
     }
 }
 
@@ -113,8 +98,6 @@ void cuda_forward(int B, int T, int C, int H, float *r, float *k, float *v, floa
 
 void cuda_backward(int B, int T, int C, int H, float *r, float *k, float *v, float *w, float *ww, float *u, float *gy, float *gr, float *gk, float *gv, float *gw, float *gu)
 {
-    dim3 threadsPerBlock( min(B*C, 32) );
-    assert(B * C % threadsPerBlock.x == 0);
-    dim3 numBlocks(B * C / threadsPerBlock.x);
-    kernel_backward<<<numBlocks, threadsPerBlock>>>(B, T, C, H, r, k, v, w, ww, u, gy, gr, gk, gv, gw, gu);
+    assert(H*N == C);
+    kernel_backward<<<dim3(B * H), dim3(N)>>>(B, T, C, H, r, k, v, w, ww, u, gy, gr, gk, gv, gw, gu);
 }

--- a/wkv5/run.py
+++ b/wkv5/run.py
@@ -382,8 +382,8 @@ elif JOB == 'benchmark' or JOB == 'torch':
 
 elif JOB == "benchmark_backward":
     B = 8
-    T = 512
-    C = 512
+    T = 4096
+    C = 4096
     HEAD_SIZE = 64
 
 H = C // HEAD_SIZE

--- a/wkv5/run.py
+++ b/wkv5/run.py
@@ -12,7 +12,7 @@ torch.backends.cuda.matmul.allow_tf32 = False
 
 # os.environ["CUDA_VISIBLE_DEVICES"] = "1"
 DEVICE = 'cuda'
-CUDA_KERNEL_VERSION = '1'
+CUDA_KERNEL_VERSION = '1e'
 
 '''
 cd /fsx/BlinkDL/CODE/_PUBLIC_/RWKV-CUDA/wkv5


### PR DESCRIPTION
v1e:


forward 10ms:

<img width="1375" alt="图片" src="https://github.com/BlinkDL/RWKV-CUDA/assets/35585791/4b08da6f-0cb7-4915-adce-8fdd634ffc28">

backward 116ms:

<img width="1421" alt="图片" src="https://github.com/BlinkDL/RWKV-CUDA/assets/35585791/ae0f4eda-720c-4914-a940-c1abc86d768d">
