### PR TITLE
less local array in kernel

### DIFF
--- a/wkv5_bf16/run.py
+++ b/wkv5_bf16/run.py
@@ -13,7 +13,7 @@ torch.backends.cuda.matmul.allow_tf32 = False
 DTYPE = torch.bfloat16
 
 DEVICE = 'cuda'
-CUDA_KERNEL_VERSION = 'v2'
+CUDA_KERNEL_VERSION = 'v1b'
 
 B = 8
 T = 4096


### PR DESCRIPTION
a800 backward:

v1b vs v2:

73ms->69.7ms。